### PR TITLE
Getting rid of materialize.js file ref

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,6 @@
     <script
         src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&libraries=places&v=weekly"
         defer></script>
-
-    <script type="text/javascript" src="js/materialize.min.js"></script>
     
     <script src="assets/js/script.js"></script>
 </body>


### PR DESCRIPTION
We have a script reference to the Materialize cdn